### PR TITLE
1.16.3 release

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@ class Gangster
           run:
         </p>
         <code>
-        npm install -g coffeelint
+        npm install -g @coffeelint/cli
         </code>
         <p>Leave off the <tt>g</tt> if you do not want to install globally.</p>
 
@@ -971,6 +971,18 @@ and warns that line numbers are probably incorrect.
           <p>
               <a href="https://github.com/coffeelint/coffeelint/compare/v3.1.0...master">Latest Changes</a>
           </p>
+
+          <div> <h3 class="changelog_header">v1.16.3</h3> <small
+          class="changelog_date">- <a
+          href="https://github.com/coffeelint/coffeelint/compare/v1.16.1...v1.16.3">2020.02.06<a></a></small>
+          <p>
+              First 1.x release under new npm package; to use: `npm install -g @coffeelint/cli@1`
+          </p>
+          <ul class="changelog_history">
+            <li>Don’t unnecessarily print “context:” at the end of some error messages
+                <a href="https://github.com/coffeelint/coffeelint/pull/42">#42</a></li>
+          </ul>
+          </div>
 
           <div> <h3 class="changelog_header">v3.1.0</h3> <small
           class="changelog_date">- <a

--- a/scripts/index-bottom.html
+++ b/scripts/index-bottom.html
@@ -213,6 +213,18 @@
               <a href="https://github.com/coffeelint/coffeelint/compare/v3.1.0...master">Latest Changes</a>
           </p>
 
+          <div> <h3 class="changelog_header">v1.16.3</h3> <small
+          class="changelog_date">- <a
+          href="https://github.com/coffeelint/coffeelint/compare/v1.16.1...v1.16.3">2020.02.06<a></a></small>
+          <p>
+              First 1.x release under new npm package; to use: `npm install -g @coffeelint/cli@1`
+          </p>
+          <ul class="changelog_history">
+            <li>Don’t unnecessarily print “context:” at the end of some error messages
+                <a href="https://github.com/coffeelint/coffeelint/pull/42">#42</a></li>
+          </ul>
+          </div>
+
           <div> <h3 class="changelog_header">v3.1.0</h3> <small
           class="changelog_date">- <a
           href="https://github.com/coffeelint/coffeelint/compare/v3.0.2...v3.1.0">2020.02.06<a></a></small>

--- a/scripts/index-top.html
+++ b/scripts/index-top.html
@@ -78,7 +78,7 @@ class Gangster
           run:
         </p>
         <code>
-        npm install -g coffeelint
+        npm install -g @coffeelint/cli
         </code>
         <p>Leave off the <tt>g</tt> if you do not want to install globally.</p>
 


### PR DESCRIPTION
Updates the instruction for installing (it was outdated right?)

Also documents the 1.16.3 release.

For some reason, the diff URL I tried to include doesn’t show any changes https://github.com/coffeelint/coffeelint/compare/v1.16.1...v1.16.3 … even though I think I pushed the latest tag to the repo… maybe you can advise on that.